### PR TITLE
Mongodb atlas querybuilder

### DIFF
--- a/docarray/index/backends/helper.py
+++ b/docarray/index/backends/helper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Type, cast
+from typing import Any, Dict, List, Tuple, Type, cast, Set
 
 from docarray import BaseDoc, DocList
 from docarray.index.abstract import BaseDocIndex
@@ -14,6 +14,43 @@ def _collect_query_args(method_name: str):  # TODO: use partialmethod instead
                 f'`{type(self)}.{method_name}`.'
                 f' Use keyword arguments instead.'
             )
+        updated_query = self._queries + [(method_name, kwargs)]
+        return type(self)(updated_query)
+
+    return inner
+
+
+def _collect_query_required_args(method_name: str, required_args: Set[str] = None):
+    """
+    Returns a function that ensures required keyword arguments are provided.
+
+    :param method_name: The name of the method for which the required arguments are being checked.
+    :type method_name: str
+    :param required_args: A set containing the names of required keyword arguments. Defaults to None.
+    :type required_args: Optional[Set[str]]
+    :return: A function that checks for required keyword arguments before executing the specified method.
+        Raises ValueError if positional arguments are provided.
+        Raises TypeError if any required keyword argument is missing.
+    :rtype: Callable
+    """
+
+    if required_args is None:
+        required_args = set()
+
+    def inner(self, *args, **kwargs):
+        if args:
+            raise ValueError(
+                f"Positional arguments are not supported for "
+                f"`{type(self)}.{method_name}`. "
+                f"Use keyword arguments instead."
+            )
+
+        missing_args = required_args - set(kwargs.keys())
+        if missing_args:
+            raise TypeError(
+                f"`{type(self)}.{method_name}` is missing required argument(s): {', '.join(missing_args)}"
+            )
+
         updated_query = self._queries + [(method_name, kwargs)]
         return type(self)(updated_query)
 

--- a/docarray/index/backends/mongodb_atlas.py
+++ b/docarray/index/backends/mongodb_atlas.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -24,6 +25,7 @@ from pymongo import MongoClient
 from docarray import BaseDoc, DocList
 from docarray.index.abstract import BaseDocIndex, _raise_not_composable
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
+from docarray.index.backends.helper import _collect_query_required_args
 from docarray.utils._internal._typing import safe_issubclass
 from docarray.utils.find import _FindResult, _FindResultBatched
 
@@ -96,12 +98,55 @@ class MongoDBAtlasDocumentIndex(BaseDocIndex, Generic[TSchema]):
         :return: True if the index exists, False otherwise.
         """
 
-    class QueryBuilder(BaseDocIndex.QueryBuilder):
-        ...
+    @dataclass
+    class Query:
+        """Dataclass describing a query."""
 
-        find = _raise_not_composable('find')
-        filter = _raise_not_composable('filter')
-        text_search = _raise_not_composable('text_search')
+        vector_fields: Optional[Dict[str, np.ndarray]]
+        filters: Optional[List[Any]]
+        text_searches: Optional[List[Any]]
+        limit: int
+
+    class QueryBuilder(BaseDocIndex.QueryBuilder):
+
+        def __init__(self, query: Optional[List[Tuple[str, Dict]]] = None):
+            super().__init__()
+            # list of tuples (method name, kwargs)
+            self._queries: List[Tuple[str, Dict]] = query or []
+
+        def build(self, limit: int) -> Any:
+            """Build the query object."""
+            search_fields: Dict[str, np.ndarray] = defaultdict(list)
+            filters: List[Any] = []
+            text_searches: List[Any] = []
+            for method, kwargs in self._queries:
+                if method == 'find':
+                    search_field = kwargs['search_field']
+                    search_fields[search_field].append(kwargs["query"])
+
+                elif method == 'filter':
+                    filters.append(kwargs)
+                else:
+                    text_searches.append(kwargs)
+
+            vector_fields = {
+                field: np.average(vectors, axis=0)
+                for field, vectors in search_fields.items()
+            }
+
+            return MongoDBAtlasDocumentIndex.Query(
+                vector_fields=vector_fields,
+                filters=filters,
+                text_searches=text_searches,
+                limit=limit,
+            )
+
+        find = _collect_query_required_args('find', {'search_field', 'query'})
+        filter = _collect_query_required_args('filter', {'query'})
+        text_search = _collect_query_required_args(
+            'text_search', {'search_field', 'query'}
+        )
+
         find_batched = _raise_not_composable('find_batched')
         filter_batched = _raise_not_composable('filter_batched')
         text_search_batched = _raise_not_composable('text_search_batched')
@@ -118,7 +163,58 @@ class MongoDBAtlasDocumentIndex(BaseDocIndex, Generic[TSchema]):
         :param kwargs: keyword arguments to pass to the query
         :return: the result of the query
         """
-        ...
+
+        pipeline: List[Dict[str, Any]] = []
+        filters: List[Dict[str, Any]] = []
+
+        # Regular filter search.
+        for filter_ in query.filters:
+            filters.append(self._filter_query(**filter_))
+
+        # check if hybrid search is needed.
+        if len(query.vector_fields) + len(query.text_searches) > 1:
+            pipeline = self._hybrid_search(
+                query.vector_fields, query.text_searches, filters, query.limit
+            )
+        else:
+            # it is a simple text with filters.
+            if query.text_searches:
+                text_stage = self._text_stage_step(**query.text_searches[0])
+                pipeline = [
+                    text_stage,
+                    {"$match": {"$and": filters} if filters else {}},
+                    {
+                        '$project': self._project_fields(
+                            extra_fields={"score": {'$meta': 'searchScore'}}
+                        )
+                    },
+                    {"$limit": query.limit},
+                ]
+            # it is a simple vector search with filters.
+            elif query.vector_fields:
+                field, vector_query = list(query.vector_fields.items())[0]
+                pipeline = [
+                    self._vector_stage_search(
+                        query=vector_query,
+                        search_field=field,
+                        limit=query.limit,
+                        filters=filters,
+                    ),
+                    {
+                        '$project': self._project_fields(
+                            extra_fields={"score": {'$meta': 'vectorSearchScore'}}
+                        )
+                    },
+                ]
+            # it is only a filter search.
+            else:
+                pipeline = [{"$match": {"$and": filters}}]
+
+        with self._doc_collection.aggregate(pipeline) as cursor:
+            docs, scores = self._mongo_to_docs(cursor)
+
+        docs = self._dict_list_to_docarray(docs)
+        return _FindResult(documents=docs, scores=scores)
 
     @dataclass
     class DBConfig(BaseDocIndex.DBConfig):
@@ -266,6 +362,103 @@ class MongoDBAtlasDocumentIndex(BaseDocIndex, Generic[TSchema]):
         if not docs:
             raise KeyError(f'No document with id {doc_ids} found')
         return docs
+
+    @staticmethod
+    def _get_score_field_by_search_field(search_field: str):
+        return f"{search_field}_score"
+
+    def _compute_reciprocal_rank(self, search_field: str):
+        penalty = self._column_infos[search_field].config["penalty"]
+        score_field = self._get_score_field_by_search_field(search_field)
+        projection_fields = {
+            key: f"$docs.{key}" for key in self._column_infos.keys() if key != "id"
+        }
+        projection_fields["_id"] = "$docs._id"
+        projection_fields[score_field] = 1
+
+        return [
+            {"$group": {"_id": None, "docs": {"$push": "$$ROOT"}}},
+            {"$unwind": {"path": "$docs", "includeArrayIndex": "rank"}},
+            {
+                "$addFields": {
+                    score_field: {"$divide": [1.0, {"$add": ["$rank", penalty, 1]}]}
+                }
+            },
+            {'$project': projection_fields},
+        ]
+
+    def _add_stage_to_pipeline(self, pipeline: List[Any], stage: Dict[str, Any]):
+        if pipeline:
+            pipeline.append(
+                {"$unionWith": {"coll": self._collection, "pipeline": stage}}
+            )
+        else:
+            pipeline.extend(stage)
+        return pipeline
+
+    def _build_final_pipeline(self, pipeline, scores_field, limit):
+        doc_fields = self._column_infos.keys()
+        grouped_fields = {
+            key: {"$first": f"${key}"} for key in doc_fields if key != "_id"
+        }
+        best_score = {score: {'$max': f'${score}'} for score in scores_field}
+        final_pipeline = [
+            {"$group": {"_id": "$_id", **grouped_fields, **best_score}},
+            {
+                "$project": {
+                    **{field: 1 for field in doc_fields},
+                    **{score: {"$ifNull": [f"${score}", 0]} for score in scores_field},
+                }
+            },
+            {
+                "$project": {
+                    "score": {"$add": [f"${score}" for score in scores_field]},
+                    **{field: 1 for field in doc_fields},
+                }
+            },
+            {"$sort": {"score": -1}},
+            {"$limit": limit},
+        ]
+        return pipeline + final_pipeline
+
+    def _hybrid_search(
+        self,
+        vector_queries: Dict[str, Any],
+        text_queries: List[Dict[str, Any]],
+        filters: Dict[str, Any],
+        limit: int,
+    ):
+
+        result_pipeline = []
+        scores_field = []
+        for search_field, query in vector_queries.items():
+            vector_stage = self._vector_stage_search(
+                query=query,
+                search_field=search_field,
+                limit=limit,
+                filters=filters,
+            )
+            pipeline = [vector_stage, *self._compute_reciprocal_rank(search_field)]
+            self._add_stage_to_pipeline(result_pipeline, pipeline)
+            scores_field.append(self._get_score_field_by_search_field(search_field))
+
+        for kwargs in text_queries:
+            text_stage = self._text_stage_step(**kwargs)
+            reciprocal_rank_stage = self._compute_reciprocal_rank(
+                kwargs["search_field"]
+            )
+            stage_pipeline = [
+                text_stage,
+                {"$match": {"$and": filters} if filters else {}},
+                {"$limit": limit},
+                *reciprocal_rank_stage,
+            ]
+            self._add_stage_to_pipeline(result_pipeline, stage_pipeline)
+            scores_field.append(
+                self._get_score_field_by_search_field(kwargs["search_field"])
+            )
+
+        return self._build_final_pipeline(result_pipeline, scores_field, limit)
 
     def _vector_stage_search(
         self,

--- a/tests/index/mongo_atlas/test_query_builder.py
+++ b/tests/index/mongo_atlas/test_query_builder.py
@@ -1,0 +1,140 @@
+import numpy as np
+
+from . import assert_when_ready
+
+
+def test_find_uses_provided_vector(simple_index):  # noqa: F811
+    index = simple_index
+
+    query = (
+        index.build_query().find(query=np.ones(10), search_field='embedding').build(7)
+    )
+
+    query_vector = query.vector_fields.pop('embedding')
+    assert query.vector_fields == {}
+    assert np.allclose(query_vector, np.ones(10))
+    assert query.filters == []
+    assert query.limit == 7
+
+
+def test_multiple_find_returns_averaged_vector(simple_index):  # noqa: F811
+    index = simple_index
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=np.ones(10), search_field='embedding')
+        .find(query=np.zeros(10), search_field='embedding')
+        .build(5)
+    )
+
+    query_vector = query.vector_fields.pop('embedding')
+    assert query.vector_fields == {}
+    assert np.allclose(query_vector, np.array([0.5] * 10))
+    assert query.filters == []
+    assert query.limit == 5
+
+
+def test_filter_passes_filter(simple_index):  # noqa: F811
+    index = simple_index
+
+    filter = {"number": {"$lt": 1}}
+    query = index.build_query().filter(query=filter).build(11)  # type: ignore[attr-defined]
+
+    assert query.vector_fields == {}
+    assert query.filters == [{"query": filter}]
+    assert query.limit == 11
+
+
+def test_query_builder_execute_query_find_filter(
+    simple_index_with_docs,  # noqa: F811
+):
+    index, docs = simple_index_with_docs
+
+    find_query = np.ones(10)
+    filter_query1 = {"number": {"$lt": 8}}
+    filter_query2 = {"number": {"$gt": 5}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .filter(query=filter_query1)
+        .filter(query=filter_query2)
+        .build(limit=5)
+    )
+
+    def pred():
+        docs = index.execute_query(query)
+
+        assert len(docs.documents) == 2
+        assert set(docs.documents.number) == {6, 7}
+
+    assert_when_ready(pred)
+
+
+def test_query_builder_execute_only_filter(
+    simple_index_with_docs,  # noqa: F811
+):
+    index, docs = simple_index_with_docs
+
+    filter_query1 = {"number": {"$lt": 8}}
+    filter_query2 = {"number": {"$gt": 5}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .filter(query=filter_query1)
+        .filter(query=filter_query2)
+        .build(limit=5)
+    )
+
+    def pred():
+        docs = index.execute_query(query)
+
+        assert len(docs.documents) == 2
+        assert set(docs.documents.number) == {6, 7}
+
+    assert_when_ready(pred)
+
+
+def test_query_builder_execute_only_filter_text(
+    simple_index_with_docs,  # noqa: F811
+):
+    index, docs = simple_index_with_docs
+
+    filter_query1 = {"number": {"$eq": 0}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .filter(query=filter_query1)
+        .build(limit=5)
+    )
+
+    def pred():
+        docs = index.execute_query(query)
+
+        assert len(docs.documents) == 1
+        assert set(docs.documents.number) == {0}
+
+    assert_when_ready(pred)
+
+
+def test_query_builder_hybrid_search(
+    simple_index_with_docs,  # noqa: F811
+):
+    find_query = np.ones(10)
+    index, docs = simple_index_with_docs
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .build(limit=10)
+    )
+
+    def pred():
+        docs = index.execute_query(query)
+
+        assert len(docs.documents) == 10
+        assert set(docs.documents.number) == {4, 5, 7, 8, 0, 6, 2, 9, 1, 3}
+
+    assert_when_ready(pred)


### PR DESCRIPTION
**Implementing MongoDB as a Document Index  Query Builder**

**Description:**
This pull request introduces add the QueryBuilder implementation, supporting build_query with MongoDB Atlas  backend. Below are the details of the implementation and its supported functionalities:

**Simple Usage:**
```python
from docarray.index import MongoAtlasDocumentIndex
import numpy as np

class MyDoc(BaseDoc):
    text: str
    embedding: NdArray[10]

docs = [MyDoc(text=f'text {i}', embedding=np.random.rand(10)) for i in range(10)]
query = np.random.rand(10)
db = MongoAtlasDocumentIndex[MyDoc](host='localhost')
db.index(docs)

query = (
        index.build_query()  # type: ignore[attr-defined]
        .find(query=find_query, search_field='embedding')
        .text_search(query="Python is a valuable skill", search_field='text')
        .build(limit=10)
    )
docs = index.execute_query(query)

```

**Supported Functionality:**
- **build_query:** Enables vector-based search, filter, and text search together.

**Limitations:**
- While implementing, faced challenges in creating Atlas vector search indexes ([PYTHON-4175](https://jira.mongodb.org/browse/PYTHON-4175)).
- Current implementation does not fully leverage text indexes. The proposal for improvement includes adding index support for text fields.

**Proposed Improvement:**
```python
class MyDoc(BaseDoc):
    text: str = Field(indexed=True)  # Proposal to enable indexing for text fields
    embedding: NdArray[10]
```

**Pre-creation of Indexes:**
In order to address the limitations mentioned above, we need to pre-create the indexes to run the unit test. Below is the mapping of collections to indexes along with their definitions:

| Collection                | Index Name     | JSON Definition Reference   |     Test set
|---------------------------|----------------|-----------------------------|---------------------------------|
| simpleschema              | vector_index   | [1]                         |  test_query_builder |
| simpleschema              | text_index     | [2]                         |      test_query_builder      |

And here are the JSON definition references:

[1] simpleschema vector_index:
```json
{
  "fields": [
    {
      "numDimensions": 10,
      "path": "embedding",
      "similarity": "cosine",
      "type": "vector"
    },
    {
      "path": "number",
      "type": "filter"
    },
    {
      "path": "text",
      "type": "filter"
    }
  ]
}
```
[2] simpleschema text_index
```json
{
  "mappings": {
    "dynamic": false,
    "fields": {
      "text": [
        {
          "type": "string"
        }
      ]
    }
  }
}
```

This addition provides clear references to the JSON definitions for each index, helping in better understanding and implementation.
